### PR TITLE
[handbook] Add v0.0.413 and v0.0.414 release notes to handbook

### DIFF
--- a/src/content/handbook/handbook.md
+++ b/src/content/handbook/handbook.md
@@ -81,7 +81,7 @@ Flags passed to the `copilot` or `gh copilot` executable.
 
 ### Interface & Mode
 
-- `--alt-screen` (v0.0.407) — Enable experimental alternate screen buffer mode (`--alt-screen on` / `--alt-screen off` syntax added in v0.0.411).
+- `--alt-screen` (v0.0.407) — Enable experimental alternate screen buffer mode (`--alt-screen on` / `--alt-screen off` syntax added in v0.0.411). Enabled by default when running with `--experimental` (v0.0.413).
 - `--acp` (v0.0.397) — Start as an Agent Client Protocol server.
 - `--agent` (v0.0.380) — Enable agent mode in interactive sessions.
 - `--resume` (v0.0.372) — Continue a remote session locally.
@@ -132,8 +132,13 @@ Flags passed to the `copilot` or `gh copilot` executable.
 - `--enable-all-github-mcp-tools` — Enable all GitHub MCP server tools.
 - `--add-github-mcp-toolset TOOLSET` — Add toolsets for the GitHub MCP server (use `all` for all toolsets).
 - `--add-github-mcp-tool TOOL` — Add tools for the GitHub MCP server (use `*` for all tools).
+- Explore agent can use GitHub MCP tools when they are enabled (v0.0.414).
 
 ### Release timeline
+
+#### 0.0.414 — 2026-02-21
+
+- Explore agent can use GitHub MCP tools when they are enabled.
 
 #### 0.0.412 — 2026-02-19
 


### PR DESCRIPTION
## What changed

Updated `src/content/handbook/handbook.md` with two user-actionable changes from the latest Copilot CLI releases.

### Command Line Arguments — v0.0.413

- Updated the `--alt-screen` bullet to note it is **enabled by default when running with `--experimental`** as of v0.0.413.
  - Source: https://github.com/github/copilot-cli/releases — _"Enable alt-screen mode by default when running with `--experimental` flag"_
  - Why relevant: users running `--experimental` will now get alt-screen automatically; they can still opt out with `--alt-screen off`.

### MCP Configuration Files — v0.0.414

- Added a bullet under **GitHub MCP server tool selection**: the **explore agent can now use GitHub MCP tools** when they are enabled via existing flags (`--enable-all-github-mcp-tools`, `--add-github-mcp-toolset`, etc.).
  - Source: https://github.com/github/copilot-cli/releases — _"Explore agent can now use GitHub MCP tools when available"_
  - Why relevant: users who enable GitHub MCP tools will now benefit from them in explore-agent tasks without extra configuration.
- Added a **0.0.414 — 2026-02-21** entry to the `### Release timeline` sub-section documenting this change.

### Sections with no qualifying new items

- **Instruction File Surface**: no new instruction-file changes in v0.0.413 or v0.0.414.
- **Slash Commands**: no new slash commands in these releases.

## Files changed

| File | Change |
|------|--------|
| `src/content/handbook/handbook.md` | Added alt-screen note for v0.0.413; added explore-agent MCP bullet and release timeline entry for v0.0.414 |

## Sources

- https://github.com/github/copilot-cli/releases (v0.0.413 and v0.0.414)

## Screenshots

Full-page screenshot of the handbook landing page after the build:

![Handbook landing page after update](https://raw.githubusercontent.com/aosama/copilot-cli-handbook/assets/update-handbook/655dc6c941341ff1aa5bb383c9ddef847e4720936ab838b9e00a695555ce38a8.png)




> Generated by [Update handbook page](https://github.com/aosama/copilot-cli-handbook/actions/runs/22251295502)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 4 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `accounts.google.com`
> - `clients2.google.com`
> - `storage.googleapis.com`
> - `www.google.com`
>
> </details>


<!-- gh-aw-agentic-workflow: Update handbook page, engine: copilot, model: claude-sonnet-4.6, run: https://github.com/aosama/copilot-cli-handbook/actions/runs/22251295502 -->

<!-- gh-aw-workflow-id: update-instruction-file-surface -->