### PR TITLE
Recompile agentic workflow lock

### DIFF
--- a/.github/workflows/update-instruction-file-surface.lock.yml
+++ b/.github/workflows/update-instruction-file-surface.lock.yml
@@ -21,11 +21,11 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Keep all sections of handbook.md aligned with recent Copilot CLI releases and GitHub Blog updates.
+# Keep index.md release sections aligned with recent Copilot CLI releases and GitHub Blog updates.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"a92358534e5f0c3f215be169577afb3ff63dc33fde4993fbbe4017b03d9e435b","compiler_version":"v0.47.4"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"9151b11b2a38a20e01452d4b0233d10a683cc3cb2fba154ee91411577439d2d2","compiler_version":"v0.47.4"}
 
-name: "Update handbook page"
+name: "Update release tracker page"
 "on":
   schedule:
   - cron: "28 4 * * *"
@@ -37,7 +37,7 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
-run-name: "Update handbook page"
+run-name: "Update release tracker page"
 
 jobs:
   activation:
@@ -302,7 +302,7 @@ jobs:
               version: "",
               agent_version: "0.0.412",
               cli_version: "v0.47.4",
-              workflow_name: "Update handbook page",
+              workflow_name: "Update release tracker page",
               experimental: false,
               supports_tools_allowlist: true,
               run_id: context.runId,
@@ -713,7 +713,7 @@ jobs:
         run: |
           set -o pipefail
           sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --allow-domains '*.githubusercontent.com,*.jsr.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bun.sh,cdn.jsdelivr.net,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,deb.nodesource.com,deno.land,esm.sh,get.pnpm.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,lfs.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,s.symcb.com,s.symcd.com,security.ubuntu.com,skimdb.npmjs.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.npmjs.com,www.npmjs.org,yarnpkg.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --enable-host-access --image-tag 0.20.2 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --model claude-sonnet-4.6 --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(cp)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(git add:*)'\'' --allow-tool '\''shell(git branch:*)'\'' --allow-tool '\''shell(git checkout:*)'\'' --allow-tool '\''shell(git commit:*)'\'' --allow-tool '\''shell(git merge:*)'\'' --allow-tool '\''shell(git rm:*)'\'' --allow-tool '\''shell(git status)'\'' --allow-tool '\''shell(git switch:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(kill)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(mkdir)'\'' --allow-tool '\''shell(mv)'\'' --allow-tool '\''shell(node)'\'' --allow-tool '\''shell(npm)'\'' --allow-tool '\''shell(npx)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(rm)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool web_fetch --allow-tool write --allow-all-paths --allow-all-urls --share /tmp/gh-aw/sandbox/agent/logs/conversation.md --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --model claude-sonnet-4.6 --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(cp)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(git add:*)'\'' --allow-tool '\''shell(git branch:*)'\'' --allow-tool '\''shell(git checkout:*)'\'' --allow-tool '\''shell(git commit:*)'\'' --allow-tool '\''shell(git merge:*)'\'' --allow-tool '\''shell(git rm:*)'\'' --allow-tool '\''shell(git status)'\'' --allow-tool '\''shell(git switch:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(kill)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(mkdir)'\'' --allow-tool '\''shell(mv)'\'' --allow-tool '\''shell(node)'\'' --allow-tool '\''shell(npm)'\'' --allow-tool '\''shell(npx)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(rm)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool web_fetch --allow-tool write --allow-all-paths --share /tmp/gh-aw/sandbox/agent/logs/conversation.md --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
@@ -916,7 +916,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: 1
-          GH_AW_WORKFLOW_NAME: "Update handbook page"
+          GH_AW_WORKFLOW_NAME: "Update release tracker page"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -929,7 +929,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Update handbook page"
+          GH_AW_WORKFLOW_NAME: "Update release tracker page"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -942,7 +942,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Update handbook page"
+          GH_AW_WORKFLOW_NAME: "Update release tracker page"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_WORKFLOW_ID: "update-instruction-file-surface"
@@ -961,7 +961,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Update handbook page"
+          GH_AW_WORKFLOW_NAME: "Update release tracker page"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -978,7 +978,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Update handbook page"
+          GH_AW_WORKFLOW_NAME: "Update release tracker page"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1023,8 +1023,8 @@ jobs:
       - name: Setup threat detection
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Update handbook page"
-          WORKFLOW_DESCRIPTION: "Keep all sections of handbook.md aligned with recent Copilot CLI releases and GitHub Blog updates."
+          WORKFLOW_NAME: "Update release tracker page"
+          WORKFLOW_DESCRIPTION: "Keep index.md release sections aligned with recent Copilot CLI releases and GitHub Blog updates."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1103,7 +1103,7 @@ jobs:
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "claude-sonnet-4.6"
       GH_AW_WORKFLOW_ID: "update-instruction-file-surface"
-      GH_AW_WORKFLOW_NAME: "Update handbook page"
+      GH_AW_WORKFLOW_NAME: "Update release tracker page"
     outputs:
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
@@ -1236,7 +1236,7 @@ jobs:
           GH_AW_ASSETS_BRANCH: "assets/update-handbook"
           GH_AW_ASSETS_MAX_SIZE_KB: 10240
           GH_AW_ASSETS_ALLOWED_EXTS: ".png"
-          GH_AW_WORKFLOW_NAME: "Update handbook page"
+          GH_AW_WORKFLOW_NAME: "Update release tracker page"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_ENGINE_MODEL: "claude-sonnet-4.6"
         with:


### PR DESCRIPTION
Fixes failing Actions run https://github.com/aosama/copilot-cli-handbook/actions/runs/22270829663.

What changed:
- Recompiled .github/workflows/update-instruction-file-surface.lock.yml to match the updated frontmatter in .github/workflows/update-instruction-file-surface.md.

Why:
- The gh-aw activation step validates that the lock file frontmatter hash matches the source workflow; it was out-of-date, so the run failed before the agent job could start.

Files:
- .github/workflows/update-instruction-file-surface.lock.yml: regenerated via .

Validation:
- 
> copilot-cli-handbook@1.0.0 lint
> prettier --check .

Checking formatting...
All matched files use Prettier code style!
- 
> copilot-cli-handbook@1.0.0 build
> astro build

13:39:30 [content] Syncing content
13:39:30 [content] Synced content
13:39:30 [types] Generated 196ms
13:39:30 [build] output: "static"
13:39:30 [build] mode: "static"
13:39:30 [build] directory: /Users/ahmedhamdy/IdeaProjects/copilot-cli-handbook/dist/
13:39:30 [build] Collecting build info...
13:39:30 [build] ✓ Completed in 201ms.
13:39:30 [build] Building static entrypoints...
13:39:30 [vite] ✓ built in 291ms
13:39:30 [build] ✓ Completed in 305ms.

 generating static routes 
13:39:30 ▶ src/pages/handbook.astro
13:39:30   └─ /handbook/index.html (+4ms) 
13:39:30 ▶ src/pages/index.astro
13:39:30   └─ /index.html (+1ms) 
13:39:30 ✓ Completed in 7ms.

13:39:30 [build] 2 page(s) built in 517ms
13:39:30 [build] Complete!