### PR TITLE
[handbook] Add release sections for v0.0.411, v0.0.412, and v0.0.413

### DIFF
--- a/src/content/handbook/index.md
+++ b/src/content/handbook/index.md
@@ -8,6 +8,39 @@ Every user-facing feature shipped in [GitHub Copilot CLI](https://github.com/git
 
 ---
 
+## 0.0.413 — 2026-02-20
+
+- `ctrl+insert` copies selected text in alt-screen view
+- Alt-screen mode enabled by default when running with `--experimental` flag
+- Support remote plugin sources (GitHub repos and git URLs) in `marketplace.json` plugin entries
+- Ctrl+A, Ctrl+E, and Ctrl+U navigate to logical line boundaries (newlines) instead of visual wrap boundaries
+- Add configurable status line to display dynamic session information via custom shell scripts
+
+## 0.0.412 — 2026-02-19
+
+- Hide custom agents with `user-invocable: false` from the `/agents` picker
+- Allow `/reset-allowed-tools` to run during agent execution
+- Add `/mcp reload` command to reload MCP configuration without restarting
+- Skills support `disable-model-invocation` frontmatter field
+- Edit plan in terminal editor with `ctrl+y`
+- Configure LSP server request timeouts in `lsp.json`
+- Add `/update` command to view changelog and update instructions
+- Support `~/.copilot/instructions/*.instructions.md` for user-level instructions across all repositories
+- Double-click selects word, triple-click selects line in alt-screen text selection
+- Edit the prompt in your preferred terminal editor with `ctrl+x ctrl+e`
+- Command files no longer require YAML frontmatter — plain markdown files work with name and description derived automatically
+- Add cross-session memory: ask about past work, files, and PRs across sessions (experimental)
+- Add `--bash-env` flag to source `BASH_ENV` in shell sessions
+- `ctrl+x /` restored as alternate shortcut to run commands while preserving input
+
+## 0.0.411 — 2026-02-17
+
+- Custom agents use `disable-model-invocation` instead of `infer` (backward compatible)
+- Support for Claude Sonnet 4.6 model
+- Support MCP servers from Windows On-Device Registry
+- Support `--alt-screen on` and `--alt-screen off` syntax
+- Add `include_coauthor` config option to disable Co-authored-by trailer in git commits
+
 ## 0.0.410 — 2026-02-14
 
 - `/init suppress` to control init suggestions per repository


### PR DESCRIPTION
## Summary

Adds three new release sections to the Release Tracker (`src/content/handbook/index.md`) covering v0.0.411 through v0.0.413, sourced from the [official copilot-cli releases page](https://github.com/github/copilot-cli/releases).

---

## Changes by release

### 0.0.413 — 2026-02-20 (new section)
- **`ctrl+insert` copies selected text in alt-screen view** — user-invocable keyboard shortcut
- **Alt-screen mode enabled by default with `--experimental` flag** — users with `--experimental` get alt-screen automatically
- **Remote plugin sources in `marketplace.json`** — users can reference GitHub repos and git URLs as plugin sources
- **Ctrl+A/E/U navigate to logical line boundaries** — keyboard navigation improvement users can rely on
- **Configurable status line via custom shell scripts** — users can configure dynamic session information display

### 0.0.412 — 2026-02-19 (new section)
- **`user-invocable: false` in agent frontmatter** — users can hide custom agents from the `/agents` picker
- **`/reset-allowed-tools` during agent execution** — users can reset tool permissions mid-session
- **`/mcp reload` command** — users can reload MCP configuration without restarting
- **`disable-model-invocation` in skill frontmatter** — users can control whether a skill uses model invocation
- **`ctrl+y` edits plan in terminal editor** — keyboard shortcut for plan editing
- **LSP timeout config in `lsp.json`** — users can configure LSP server request timeouts
- **`/update` command** — users can view changelog and update instructions
- **`~/.copilot/instructions/*.instructions.md`** — users can place instruction files at user level that apply across all repos
- **Double-click word / triple-click line selection** — alt-screen text selection shortcuts
- **`ctrl+x ctrl+e` edits prompt in terminal editor** — users can invoke their preferred editor for the prompt
- **Command files without YAML frontmatter** — plain markdown files work as command files with name/description auto-derived
- **Cross-session memory (experimental)** — users can ask about past work, files, and PRs across sessions
- **`--bash-env` flag** — sources `BASH_ENV` in shell sessions
- **`ctrl+x /` restored** — alternate shortcut to run commands while preserving input

### 0.0.411 — 2026-02-17 (new section)
- **`disable-model-invocation` replaces `infer`** — updated frontmatter field for custom agents (backward compatible)
- **Claude Sonnet 4.6 model** — new model users can select
- **MCP servers from Windows On-Device Registry** — Windows users can configure MCP via On-Device Registry
- **`--alt-screen on/off` syntax** — users can use explicit on/off values for the flag
- **`include_coauthor` config option** — users can disable Co-authored-by trailer in git commits

---

## Files changed

| File | Change |
|------|--------|
| `src/content/handbook/index.md` | Added 3 new release sections (33 lines inserted) |

---

## Filtering rationale

Excluded entries that were:
- Bug fixes and internal behavior changes with no user action required
- Passive performance improvements (memory usage, speed)
- SDK/API internals not exposed to end users
- Recovery/hotfix items restoring existing functionality

Release 0.0.414 had zero qualifying user-actionable bullets (both entries were automatic/passive UI behaviors) and was omitted per the content rules.

---

## Sources

- https://github.com/github/copilot-cli/releases (official release notes)

---

## Screenshots

Screenshots could not be captured in this run due to environment restrictions (network-locked sandbox preventing Playwright and preview server access). The build completed successfully (`astro build` — 2 pages built in 1.85s), confirming the Markdown changes parse and render correctly.




> Generated by [Update release tracker page](https://github.com/aosama/copilot-cli-handbook/actions/runs/22283309758)

<!-- gh-aw-agentic-workflow: Update release tracker page, engine: copilot, model: claude-sonnet-4.6, run: https://github.com/aosama/copilot-cli-handbook/actions/runs/22283309758 -->

<!-- gh-aw-workflow-id: update-instruction-file-surface -->