### PR TITLE
[handbook] Add v0.0.414 release section to Release Tracker

### DIFF
--- a/src/content/handbook/index.md
+++ b/src/content/handbook/index.md
@@ -8,6 +8,10 @@ Every user-facing feature shipped in [GitHub Copilot CLI](https://github.com/git
 
 ---
 
+## 0.0.414 — 2026-02-21
+
+- Explore agent can now use GitHub MCP tools when available
+
 ## 0.0.413 — 2026-02-20
 
 - `ctrl+insert` copies selected text in alt-screen view


### PR DESCRIPTION
## What changed

Added a new release section for **v0.0.414 (2026-02-21)** to `src/content/handbook/index.md`.

### New content

**`## 0.0.414 — 2026-02-21`**

- Explore agent can now use GitHub MCP tools when available

### Files touched

- `src/content/handbook/index.md` — added the `## 0.0.414 — 2026-02-21` section at the top of the release list (newest-first order)

### Sources used

- https://github.com/github/copilot-cli/releases (official release notes for 0.0.414)

### Why this change is relevant

The bullet "Explore agent can now use GitHub MCP tools when available" is directly user-actionable: a user can invoke the explore agent and it will now have access to GitHub MCP tools (when configured), enabling richer code search and GitHub operations. This passes the "Can a user go try it right now?" test.

The second bullet in the release ("Show permission elevation dialog when accepting a plan with autopilot to prevent auto-denied tool errors") was excluded as it describes automatic error-prevention behavior the user does not directly control.

## Screenshots

![Release Tracker after update](https://raw.githubusercontent.com/aosama/copilot-cli-handbook/assets/update-handbook/3cf2e960a60e3d0db93eccd16638511007f87d29838723cae39397abc241b93b.png)




> Generated by [Update release tracker page](https://github.com/aosama/copilot-cli-handbook/actions/runs/22293689093)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 5 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `accounts.google.com`
> - `clients2.google.com`
> - `redirector.gvt1.com`
> - `storage.googleapis.com`
> - `www.google.com`
>
> </details>


<!-- gh-aw-agentic-workflow: Update release tracker page, engine: copilot, model: claude-sonnet-4.6, run: https://github.com/aosama/copilot-cli-handbook/actions/runs/22293689093 -->

<!-- gh-aw-workflow-id: update-instruction-file-surface -->