### PR TITLE
[handbook] Add v0.0.415 release section to release tracker

### DIFF
--- a/src/content/handbook/index.md
+++ b/src/content/handbook/index.md
@@ -8,6 +8,15 @@ Every user-facing feature shipped in [GitHub Copilot CLI](https://github.com/git
 
 ---
 
+## 0.0.415 — 2026-02-23
+
+- Custom agents support the `model` field to specify which model to use
+- Plan approval menu shows model-curated actions with a recommended option highlighted first, including autopilot+fleet for parallelizable work
+- Add `show_file` tool for presenting code and diffs to the user
+- `/plugin marketplace add` and `/plugin install` support local paths containing spaces
+- `/mcp show` groups servers into User, Workspace, Plugins, and Built-in sections and makes all servers navigable
+- Ctrl+A/E cycle through visual lines in wrapped input; Home/End navigate within a visual line; Ctrl+Home/End jump to text boundaries
+
 ## 0.0.414 — 2026-02-21
 
 - Explore agent can now use GitHub MCP tools when available


### PR DESCRIPTION
## Summary

Adds a new release section for **v0.0.415** (2026-02-23) to the Release Tracker in `src/content/handbook/index.md`.

## What changed

### `src/content/handbook/index.md`

Added the following section at the top of the release list (newest-first):

````markdown
## 0.0.415 — 2026-02-23

- Custom agents support the `model` field to specify which model to use
- Plan approval menu shows model-curated actions with a recommended option highlighted first, including autopilot+fleet for parallelizable work
- Add `show_file` tool for presenting code and diffs to the user
- `/plugin marketplace add` and `/plugin install` support local paths containing spaces
- `/mcp show` groups servers into User, Workspace, Plugins, and Built-in sections and makes all servers navigable
- Ctrl+A/E cycle through visual lines in wrapped input; Home/End navigate within a visual line; Ctrl+Home/End jump to text boundaries
````

## Sources

- https://github.com/github/copilot-cli/releases (v0.0.415 release notes, 2026-02-23)

## Why each bullet is included

| Bullet | Rationale |
|--------|-----------|
| Custom agents `model` field | User can add a `model:` key to their agent frontmatter to pin a specific model — directly configurable. |
| Plan approval menu with recommended option | User can see and select model-curated actions (including autopilot+fleet) when approving a plan — user-invocable. |
| `show_file` tool | New tool the agent can invoke to present code/diffs; visible and useful to users during agent sessions. |
| `/plugin install` supports local paths with spaces | Users running `/plugin marketplace add` or `/plugin install` with space-containing paths now work correctly — improves an invocable command. |
| `/mcp show` grouping | `/mcp show` now groups servers into User, Workspace, Plugins, and Built-in sections with navigation — improved UX for an existing command. |
| Ctrl+A/E / Home/End keyboard shortcuts | New keyboard bindings users can use immediately in wrapped-input navigation. |

**Excluded items** (per content rules):
- Skill UTF-8 BOM fix — bug fix restoring broken functionality
- Unknown agent fields warn instead of blocking — passive/internal behavior
- Env loading indicator — passive UI indicator with no user action required
- MCP truncation fix — bug fix

## Screenshots

Full-page screenshot of the Release Tracker page after the update:

![Release Tracker with v0.0.415 section](https://raw.githubusercontent.com/aosama/copilot-cli-handbook/assets/update-handbook/aaa6e32886d224841970fec3f97c22363c6e3ab3382eefec8c0a07b20ff63e2f.png)




> Generated by [Update release tracker page](https://github.com/aosama/copilot-cli-handbook/actions/runs/22337402044)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 4 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `accounts.google.com`
> - `clients2.google.com`
> - `storage.googleapis.com`
> - `www.google.com`
>
> </details>


<!-- gh-aw-agentic-workflow: Update release tracker page, engine: copilot, model: claude-sonnet-4.6, run: https://github.com/aosama/copilot-cli-handbook/actions/runs/22337402044 -->

<!-- gh-aw-workflow-id: update-instruction-file-surface -->