### PR TITLE
[handbook] Add v0.0.416 and v0.0.417 release sections to Release Tracker

### DIFF
--- a/src/content/handbook/index.md
+++ b/src/content/handbook/index.md
@@ -8,6 +8,16 @@ Every user-facing feature shipped in [GitHub Copilot CLI](https://github.com/git
 
 ---
 
+## 0.0.417 — 2026-02-25
+
+- `/research` command for deep research with exportable reports
+- Plugin skills and commands load from custom paths declared in `plugin.json`
+
+## 0.0.416 — 2026-02-24
+
+- `--help` content expanded with descriptions, examples, and sorted flags
+- Undo operations now always require confirmation
+
 ## 0.0.415 — 2026-02-23
 
 - Custom agents support the `model` field to specify which model to use


### PR DESCRIPTION
## What changed

Added two new release sections to `src/content/handbook/index.md`:

### v0.0.417 — 2026-02-25
- `/research` command for deep research with exportable reports — new user-invocable command
- Plugin skills and commands load from custom paths declared in `plugin.json` — user-configurable plugin behavior

### v0.0.416 — 2026-02-24
- `--help` content expanded with descriptions, examples, and sorted flags — users can now get richer help output
- Undo operations now always require confirmation — behavioral change users will notice

## Why each bullet was included

All bullets pass the "Can a user read this and go try it right now?" test:
- `/research` is a new slash command users can invoke directly
- Custom paths in `plugin.json` is a configurable option for plugin authors/users
- `--help` improvement is directly usable by running `copilot --help`
- Undo confirmation is a behavioral change users will encounter when undoing

## Excluded items

**0.0.417:**
- "MCP servers no longer intermittently fail to load" — passive fix, not user-actionable
- "Plugin agents and skills are available immediately after install" — passive improvement
- "Alt+backspace correctly registers as backspace" — bug fix

**0.0.416:**
- "Block third-party MCP servers when the Copilot MCP policy does not allow them" — backend enforcement policy
- "Streaming response size counter updates continuously" — passive UI improvement
- "Status line automatically switches to a two-line layout on narrow terminals" — passive/automatic

## Source links

- https://github.com/github/copilot-cli/releases — official release notes for v0.0.416 and v0.0.417

## Screenshots

> ⚠️ Note: The build environment prevented running `npm ci` / `npm run build` (external binary execution is blocked in the agentic workflow sandbox). Screenshots could not be captured from the local preview server. The content changes are limited to `index.md` and follow the established format from prior releases.




> Generated by [Update release tracker page](https://github.com/aosama/copilot-cli-handbook/actions/runs/22383041803)

<!-- gh-aw-agentic-workflow: Update release tracker page, engine: copilot, model: claude-sonnet-4.6, run: https://github.com/aosama/copilot-cli-handbook/actions/runs/22383041803 -->

<!-- gh-aw-workflow-id: update-instruction-file-surface -->