### PR TITLE
[handbook] Add v0.0.419 and v0.0.420 release sections to Release Tracker

### DIFF
--- a/src/content/handbook/index.md
+++ b/src/content/handbook/index.md
@@ -8,6 +8,19 @@ Every user-facing feature shipped in [GitHub Copilot CLI](https://github.com/git
 
 ---
 
+## 0.0.420 — 2026-02-27
+
+- Type `#` to reference GitHub issues, pull requests, and discussions
+
+## 0.0.419 — 2026-02-27
+
+- `/chronicle` command with `standup`, `tips`, and `improve` subcommands powered by session history (experimental)
+- `--mouse`/`--no-mouse` flag and `mouse` config to disable mouse mode in alt-screen
+- Ctrl+F/Ctrl+B as page down/up shortcuts for scrolling in alt-screen views
+- Home and End keys jump to the top and bottom of the alt-screen scroll buffer
+- Ctrl+G keyboard shortcut for editing prompts in external editor and dismissing UI elements
+- MCP server names now support dots, slashes, and `@` characters (e.g., `@modelcontextprotocol/server`, `io.github/server`)
+
 ## 0.0.418 — 2026-02-25
 
 - GitHub Copilot CLI is now [generally available](https://github.blog/changelog/2026-02-25-github-copilot-cli-is-now-generally-available)


### PR DESCRIPTION
## What changed

Added two new release sections to `src/content/handbook/index.md` for versions 0.0.419 and 0.0.420, which were not yet reflected in the Release Tracker.

## Files changed

- `src/content/handbook/index.md` — added 13 lines (two new release sections at the top, newest-first)

## Changes by release

### v0.0.420 — 2026-02-27

Source: https://github.com/github/copilot-cli/releases/tag/v0.0.420

- **`Type # to reference GitHub issues, pull requests, and discussions`** — new input shortcut users can invoke directly in the prompt

### v0.0.419 — 2026-02-27

Source: https://github.com/github/copilot-cli/releases/tag/v0.0.419

- **`/chronicle` command** with `standup`, `tips`, and `improve` subcommands (experimental) — user-invocable command
- **`--mouse`/`--no-mouse` flag** and `mouse` config — users can disable mouse mode in alt-screen
- **Ctrl+F/Ctrl+B** as page down/up shortcuts in alt-screen views — user-invocable keyboard shortcuts
- **Home/End keys** jump to top/bottom of alt-screen scroll buffer — user-invocable keyboard shortcuts
- **Ctrl+G** keyboard shortcut for editing prompts in external editor and dismissing UI elements — user-invocable shortcut
- **MCP server names** now support dots, slashes, and `@` characters — users can configure MCP servers with npm-style names like `@modelcontextprotocol/server`

## Excluded items (per content rules)

The following were excluded as they don't meet the "user can try it right now" test:
- Bug fixes and recovery items (scrolling regressions, 502 retries, spinner fix, /mcp enable fix)
- Passive/automatic improvements (AUTO theme color accuracy, MCP env var auto-inclusion, /diagnose message improvement)

## Screenshots

Full-page screenshot of the Release Tracker page after the update:

![Release Tracker updated with v0.0.419 and v0.0.420](https://raw.githubusercontent.com/aosama/copilot-cli-handbook/assets/update-handbook/e14c2d231ebeb0310c0467d4a2d113bc8fbcd97d171f395e02b93e41ebd852b3.png)




> Generated by [Update release tracker page](https://github.com/aosama/copilot-cli-handbook/actions/runs/22513609324)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 4 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `accounts.google.com`
> - `clients2.google.com`
> - `storage.googleapis.com`
> - `www.google.com`
>
> </details>


<!-- gh-aw-agentic-workflow: Update release tracker page, engine: copilot, model: claude-sonnet-4.6, run: https://github.com/aosama/copilot-cli-handbook/actions/runs/22513609324 -->

<!-- gh-aw-workflow-id: update-instruction-file-surface -->