### PR TITLE
[handbook] Add release tracker entries for v0.0.419 and v0.0.420

### DIFF
--- a/src/content/handbook/index.md
+++ b/src/content/handbook/index.md
@@ -8,6 +8,19 @@ Every user-facing feature shipped in [GitHub Copilot CLI](https://github.com/git
 
 ---
 
+## 0.0.420 — 2026-02-27
+
+- Type `#` to reference GitHub issues, pull requests, and discussions in prompts
+
+## 0.0.419 — 2026-02-27
+
+- `/chronicle` command with `standup`, `tips`, and `improve` subcommands powered by session history (experimental)
+- `Ctrl+F`/`Ctrl+B` as page down/up shortcuts for scrolling in alt-screen views
+- `--mouse`/`--no-mouse` flag and `mouse` config option to disable mouse mode in alt screen
+- Home and End keys jump to the top and bottom of the alt-screen scroll buffer
+- `Ctrl+G` keyboard shortcut for editing prompts in external editor and dismissing UI elements
+- MCP server names now support dots, slashes, and `@` characters (e.g., `@modelcontextprotocol/server`)
+
 ## 0.0.418 — 2026-02-25
 
 - GitHub Copilot CLI is now [generally available](https://github.blog/changelog/2026-02-25-github-copilot-cli-is-now-generally-available)
@@ -475,4 +488,4 @@ Every user-facing feature shipped in [GitHub Copilot CLI](https://github.com/git
 
 ---
 
-Source: [github/copilot-cli/releases](https://github.com/github/copilot-cli/releases) · Last updated: February 2026
+Source: [github/copilot-cli/releases](https://github.com/github/copilot-cli/releases) · Last updated: March 2026


### PR DESCRIPTION
## What changed

Added two new release sections to `src/content/handbook/index.md` for versions released on 2026-02-27, and updated the "Last updated" footer to March 2026.

---

### 0.0.420 — 2026-02-27

One user-actionable feature added:

- **Type `#` to reference GitHub issues, pull requests, and discussions in prompts** — users can now type `#` as a shortcut to insert references to GitHub issues, PRs, and discussions directly while composing a prompt.

Excluded items:
- Auto-update binary/JS package updates (passive/automatic)
- Plugin/marketplace git repo fix (bug fix)
- 502 bad gateway retry (passive/internal)
- Copy hint shows cmd+c (passive UI change, no user action)

---

### 0.0.419 — 2026-02-27

Six user-actionable features added:

- **`/chronicle` command** with `standup`, `tips`, and `improve` subcommands powered by session history (experimental)
- **`Ctrl+F`/`Ctrl+B`** as page down/up shortcuts for scrolling in alt-screen views
- **`--mouse`/`--no-mouse` flag and `mouse` config option** to disable mouse mode in alt screen
- **Home and End keys** jump to the top and bottom of the alt-screen scroll buffer
- **`Ctrl+G` keyboard shortcut** for editing prompts in external editor and dismissing UI elements
- **MCP server names now support dots, slashes, and `@` characters**, enabling npm-style names like `@modelcontextprotocol/server`

Excluded items:
- Mouse scroll button fix (bug fix)
- CLI spinner fix (bug fix)
- AUTO theme palette change (passive improvement)
- MCP server env vars auto-inclusion (automatic/passive)
- `/diagnose` message improvement (minor UX, no user action)

---

## Files changed

- `src/content/handbook/index.md` — added 14 lines: two new release sections at the top of the release list, and updated the footer date from "February 2026" to "March 2026"

## Source links

- https://github.com/github/copilot-cli/releases (official release notes)

## Screenshots

Release Tracker page after update:

![Release Tracker updated](https://raw.githubusercontent.com/aosama/copilot-cli-handbook/assets/update-handbook/2254966fd463989a25ae5f6ad99f3e3d4ef9c106a2047a63db9146198303d76d.png)




> Generated by [Update release tracker page](https://github.com/aosama/copilot-cli-handbook/actions/runs/22536417404)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 5 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `accounts.google.com`
> - `clients2.google.com`
> - `redirector.gvt1.com`
> - `storage.googleapis.com`
> - `www.google.com`
>
> </details>


<!-- gh-aw-agentic-workflow: Update release tracker page, engine: copilot, model: claude-sonnet-4.6, run: https://github.com/aosama/copilot-cli-handbook/actions/runs/22536417404 -->

<!-- gh-aw-workflow-id: update-instruction-file-surface -->