### PR TITLE
[handbook] Add v0.0.419 and v0.0.420 release sections to Release Tracker

### DIFF
--- a/src/content/handbook/index.md
+++ b/src/content/handbook/index.md
@@ -8,6 +8,20 @@ Every user-facing feature shipped in [GitHub Copilot CLI](https://github.com/git
 
 ---
 
+## 0.0.420 — 2026-02-27
+
+- Type `#` to reference GitHub issues, pull requests, and discussions
+- Auto-update now also updates the binary executable, not just the JS package
+
+## 0.0.419 — 2026-02-27
+
+- `/chronicle` command with standup, tips, and improve subcommands powered by session history (experimental)
+- `--mouse`/`--no-mouse` flag and `mouse` config option to disable mouse mode in alt-screen
+- Ctrl+F/Ctrl+B as page down/up shortcuts for scrolling in alt-screen views
+- Home and End keys jump to the top and bottom of the alt-screen scroll buffer
+- Ctrl+G keyboard shortcut for editing prompts in external editor and dismissing UI elements
+- MCP server names now support dots, slashes, and `@` characters, enabling npm-style names like `@modelcontextprotocol/server`
+
 ## 0.0.418 — 2026-02-25
 
 - GitHub Copilot CLI is now [generally available](https://github.blog/changelog/2026-02-25-github-copilot-cli-is-now-generally-available)


### PR DESCRIPTION
## What changed

Added two new release sections to `src/content/handbook/index.md` for **v0.0.420** (2026-02-27) and **v0.0.419** (2026-02-27), inserted above the existing v0.0.418 section in newest-first order.

## Files changed

- `src/content/handbook/index.md` — added 14 lines (two new release sections)

## Changes by release

### v0.0.420 — 2026-02-27

| Bullet | Why included |
|--------|-------------|
| Type `#` to reference GitHub issues, PRs, and discussions | Direct user gesture — user can type `#` right now to reference GitHub items |
| Auto-update now also updates the binary executable, not just the JS package | Behavioral change users benefit from when running `copilot update` |

Excluded: 502 error retry (passive/automatic), copy hint UI change (informational), plugin git repo fix (bug fix).

### v0.0.419 — 2026-02-27

| Bullet | Why included |
|--------|-------------|
| `/chronicle` command with standup, tips, and improve subcommands (experimental) | New slash command user can invoke |
| `--mouse`/`--no-mouse` flag and `mouse` config option | New flag user can opt into/out of |
| Ctrl+F/Ctrl+B page down/up shortcuts in alt-screen | Keyboard shortcut user can use |
| Home/End keys jump to top/bottom of alt-screen scroll buffer | Keyboard shortcut user can use |
| Ctrl+G shortcut for editing prompts in external editor | Keyboard shortcut user can use |
| MCP server names now support dots, slashes, and `@` characters | User can now name MCP servers with npm-style names |

Excluded: scrolling bug fix, CLI spinner fix, `/mcp enable` fix (bug fixes/restoring functionality), `/diagnose` message improvement (passive UI change), AUTO theme color improvement (passive), MCP env var auto-inclusion (automatic behavior).

## Source links

- https://github.com/github/copilot-cli/releases (official release notes for v0.0.419 and v0.0.420)

## Screenshots

Full-page screenshot of the Release Tracker page after update:

![Release Tracker after update](https://raw.githubusercontent.com/aosama/copilot-cli-handbook/assets/update-handbook/655dc6c941341ff1aa5bb383c9ddef847e4720936ab838b9e00a695555ce38a8.png)




> Generated by [Update release tracker page](https://github.com/aosama/copilot-cli-handbook/actions/runs/22562110499)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 4 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `accounts.google.com`
> - `clients2.google.com`
> - `storage.googleapis.com`
> - `www.google.com`
>
> </details>


<!-- gh-aw-agentic-workflow: Update release tracker page, engine: copilot, model: claude-sonnet-4.6, run: https://github.com/aosama/copilot-cli-handbook/actions/runs/22562110499 -->

<!-- gh-aw-workflow-id: update-instruction-file-surface -->